### PR TITLE
Обновление catalogFill

### DIFF
--- a/assets/modules/catalogFill/classes/catalogfill.class.php
+++ b/assets/modules/catalogFill/classes/catalogfill.class.php
@@ -342,7 +342,7 @@ function groupInsertToDB($insertArr){
                 if($this->config['imp_upd_parent']==false) unset($val['content']['parent']);
                 $contentArr = array_merge($this->config['imp_content_default']['content'],$val['content']);
                 foreach($contentArr as $k => $v){
-                    // KANBY обновлять alias у существующих товаров?
+                    // обновлять alias у существующих товаров?
                     if ($k == 'alias' && $this->config['imp_upd_alias']==false) continue;
                     $updateContentStr .= " `$k` = '$v',";
                 }

--- a/assets/modules/catalogFill/classes/catalogfill.class.php
+++ b/assets/modules/catalogFill/classes/catalogfill.class.php
@@ -326,8 +326,7 @@ function groupInsertToDB($insertArr){
                 $select_q = "
                     SELECT sc.id FROM ".$this->config['content_table']." sc
                     LEFT JOIN ".$this->config['tmplvar_content_table']." tvc ON sc.id = tvc.contentid
-                    WHERE sc.parent = '".$val['content']['parent']."'
-                    AND tvc.tmplvarid = '".$this->config['imp_chk_tvid_val']."'
+                    WHERE tvc.tmplvarid = '".$this->config['imp_chk_tvid_val']."'
                     AND tvc.value = '".$tvArr[$this->config['imp_chk_tvid_val']]."'
                 ";
                 $upd_id = $this->modx->db->getValue($this->modx->db->query($select_q));
@@ -339,8 +338,12 @@ function groupInsertToDB($insertArr){
                 
                 $updateContentStr = "UPDATE ".$this->config['content_table']." SET";
                 if($this->config['imp_chk_field']=='id') unset($val['content']['id']);
+                // оставлять товар в текущей категории?
+                if($this->config['imp_upd_parent']==false) unset($val['content']['parent']);
                 $contentArr = array_merge($this->config['imp_content_default']['content'],$val['content']);
                 foreach($contentArr as $k => $v){
+                    // KANBY обновлять alias у существующих товаров?
+                    if ($k == 'alias' && $this->config['imp_upd_alias']==false) continue;
                     $updateContentStr .= " `$k` = '$v',";
                 }
                 unset($k,$v);

--- a/assets/modules/catalogFill/classes/catalogfill.class.php
+++ b/assets/modules/catalogFill/classes/catalogfill.class.php
@@ -925,6 +925,22 @@ function makeAlias($str){
           )
       );
     }
+    
+    // проверка на дублирование alias
+    if($this->modx->db->getRecordCount($this->modx->db->select("alias", $this->modx->getFullTableName('site_content'),  "alias='" . $str ."'")) != 0) {
+
+        $count = 1;
+        $newAlias = $str;
+
+        while($this->modx->db->getRecordCount($this->modx->db->select("alias", $this->modx->getFullTableName('site_content'),  "alias='" . $newAlias ."'")) != 0) {
+            $newAlias = $str;
+            $newAlias .= '-' . $count;
+            $count++;
+        }
+
+        $str = $newAlias;
+    }
+    
     return $str;
 }
 

--- a/assets/modules/catalogFill/config/default.php
+++ b/assets/modules/catalogFill/config/default.php
@@ -61,6 +61,12 @@ $cf_config['exp_csv_charset'] = 'UTF-8'; //'windows-1251'
 //тестирование конфигурации (без записи в БД)
 $cf_config['imp_testmode'] = false;
 
+// обновлять (alias) у существующих товаров
+$cf_config['imp_upd_alias'] = false;
+
+// обновлять категории (parent) у существующих товаров
+$cf_config['imp_upd_parent'] = true;
+
 
 //функция для фильтрации значений при ИМПОРТЕ
 function filter_import($value_arr){


### PR DESCRIPTION
Столкнулся с нескольким проблемами:
- если товар в файле импорта перешел в новую категорию, то создается новый товар в новой категории, а старый остается
- alias по необходимости может быть отредактирован вручную (например, дубли alias), а после нового импорта сгенерируется старый alias и затрет исправленный
- категория товара может быть изменена в файле импорта и не всегда есть необходимость перекладывать товар согласно этому файлу (при ручном управлении категорией товара через админку)